### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 src/Examples/cache/
 .idea/
+*.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
-dist: trusty
 sudo: true
 php:
   - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
   - nightly
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {


### PR DESCRIPTION
# Changed log
- Add `php-7.3` and `php-7.4` version tests on Travis CI build.
- Remove `trusty` dist because the `xenial` dist is enabled by default on Travis CI build.
And default dist on Travis CI build has included all `php-7.x` versions.
- Add `*.cache` file on `.gitignore` file to let these files avoid being under Git version control.